### PR TITLE
Refactor icon handling, add property-change helpers, tests, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small GNOME Shell extension that shows running AppIndicator / StatusNotifier a
 
 This is still pretty experimental and mostly something I built for myself.
 
-_Disclaimer: I have no with experience gtk / gnome-shell code.. so AI was/is heavily used_
+_Disclaimer: I have no experience with GTK or GNOME Shell code, so AI was/is heavily used._
 
 <img width="389" height="530" alt="image" src="https://github.com/user-attachments/assets/e2f29c03-734b-4bbe-ba41-fe63dc93e947" />
 
@@ -14,12 +14,20 @@ _Disclaimer: I have no with experience gtk / gnome-shell code.. so AI was/is hea
   - [x] App Icon and menu
   - [x] Submenu
   - [x] Scrollable on overflow (hardcoded to 600px atm) 
-- [ ] Add Exceptions to show it on systray 
+- [ ] Add per-application inclusion/exclusion settings
+
+> [!NOTE]
+> This extension provides the `org.kde.StatusNotifierWatcher` service itself.
+> It therefore cannot run alongside another AppIndicator/KStatusNotifierItem
+> extension that owns the same service. Any future filtering will control which
+> applications appear in this extension; it will not route excluded applications
+> to a separate system tray extension.
+
 ## Credits
 
 A lot of the implementation is based on the AppIndicator/KStatusNotifier extensions.
 
 ### Alternative methods I tried and abandoned
 
-- Git submoduling AppIndicator/KStatusNotifier and adding an adapter but the code was way too coupled and I was pratically initialising their extension.
-- Copying Background Apps Implementation but that were gnome internals that have no guarantee and extension risk breakage with every update even without entangling myself in internal APIs.
+- Using AppIndicator/KStatusNotifier as a Git submodule and adding an adapter, but the code was too tightly coupled and I was practically initializing the other extension.
+- Copying the Background Apps implementation, but it uses GNOME internals that provide no stability guarantees and risk breaking the extension with every update.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/iconNames.js
+++ b/src/iconNames.js
@@ -1,0 +1,17 @@
+export function normalizeIconName(name) {
+    if (!name)
+        return null;
+
+    /* Absolute paths must never be treated as theme icon names. */
+    if (name.startsWith('/'))
+        return name;
+
+    const lower = name.toLowerCase();
+
+    for (const extension of ['.svg', '.png']) {
+        if (lower.endsWith(extension))
+            return name.slice(0, -extension.length);
+    }
+
+    return name;
+}

--- a/src/iconUtils.js
+++ b/src/iconUtils.js
@@ -5,6 +5,13 @@ import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import St from 'gi://St';
 
+import {
+    normalizeIconName,
+} from './iconNames.js';
+
+
+export {normalizeIconName} from './iconNames.js';
+
 
 Gio._promisify(
     GdkPixbuf.Pixbuf,
@@ -255,25 +262,6 @@ export async function setDbusMenuIconData(
         );
         return false;
     }
-}
-
-
-export function normalizeIconName(name) {
-    if (!name)
-        return null;
-
-    /* Absolute paths must never be treated as theme icon names. */
-    if (name.startsWith('/'))
-        return name;
-
-    const lower = name.toLowerCase();
-
-    for (const extension of ['.svg', '.png']) {
-        if (lower.endsWith(extension))
-            return name.slice(0, -extension.length);
-    }
-
-    return name;
 }
 
 

--- a/src/propertyChanges.js
+++ b/src/propertyChanges.js
@@ -1,0 +1,18 @@
+export const ICON_PROPERTIES = Object.freeze([
+    'IconName',
+    'IconPixmap',
+    'AttentionIconName',
+    'AttentionIconPixmap',
+    'IconThemePath',
+]);
+
+
+export function collectChangedPropertyNames(
+    values,
+    invalidated = []
+) {
+    return new Set([
+        ...Object.keys(values),
+        ...invalidated,
+    ]);
+}

--- a/src/runningAppsToggle.js
+++ b/src/runningAppsToggle.js
@@ -73,6 +73,11 @@ extends QuickToggle {
                 this.menu.open();
             }
         );
+
+        this.connect(
+            'destroy',
+            () => this._onDestroy()
+        );
     }
 
 
@@ -257,11 +262,9 @@ extends QuickToggle {
     }
 
 
-    destroy() {
+    _onDestroy() {
         /*
          * Restore GNOME's original method.
-         *
-         * No super.destroy() here.
          */
         if (
             this._originalSetOpenedSubMenu

--- a/src/runningAppsToggle.js
+++ b/src/runningAppsToggle.js
@@ -73,6 +73,12 @@ extends QuickToggle {
                 this.menu.open();
             }
         );
+
+        this.connect(
+                   'destroy',
+                   () => this._onDestroy()
+               );
+
     }
 
 
@@ -257,7 +263,7 @@ extends QuickToggle {
     }
 
 
-    destroy() {
+    _onDestroy() {
         /*
          * Restore GNOME's original method.
          *

--- a/src/statusNotifierItem.js
+++ b/src/statusNotifierItem.js
@@ -8,6 +8,11 @@ import {
     STATUS_NOTIFIER_ITEM_IFACE,
 } from './interfaces.js';
 
+import {
+    collectChangedPropertyNames,
+    ICON_PROPERTIES,
+} from './propertyChanges.js';
+
 
 export const SNIStatus = Object.freeze({
     PASSIVE: 'Passive',
@@ -100,22 +105,26 @@ export class StatusNotifierItem extends Signals.EventEmitter {
         for (const name of invalidated)
             this._properties.delete(name);
 
+        const changedNames =
+            collectChangedPropertyNames(
+                values,
+                invalidated
+            );
+
         this.emit('changed');
 
-        if ('Status' in values)
+        if (changedNames.has('Status'))
             this.emit('status-changed');
 
         if (
-            'IconName' in values ||
-            'IconPixmap' in values ||
-            'AttentionIconName' in values ||
-            'AttentionIconPixmap' in values ||
-            'IconThemePath' in values
+            ICON_PROPERTIES.some(
+                name => changedNames.has(name)
+            )
         ) {
             this.emit('icon-changed');
         }
 
-        if ('Menu' in values)
+        if (changedNames.has('Menu'))
             this.emit('menu-changed');
     }
 

--- a/test/iconNames.test.js
+++ b/test/iconNames.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {normalizeIconName} from '../src/iconNames.js';
+
+
+test('normalizeIconName removes supported file extensions', () => {
+    assert.equal(normalizeIconName('example.svg'), 'example');
+    assert.equal(normalizeIconName('example.PNG'), 'example');
+});
+
+
+test('normalizeIconName preserves paths and ordinary icon names', () => {
+    assert.equal(
+        normalizeIconName('/opt/example/icon.svg'),
+        '/opt/example/icon.svg'
+    );
+    assert.equal(normalizeIconName('example-symbolic'), 'example-symbolic');
+    assert.equal(normalizeIconName(null), null);
+});

--- a/test/propertyChanges.test.js
+++ b/test/propertyChanges.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    collectChangedPropertyNames,
+    ICON_PROPERTIES,
+} from '../src/propertyChanges.js';
+
+
+test('collectChangedPropertyNames includes changed and invalidated properties', () => {
+    const names = collectChangedPropertyNames(
+        {Status: 'Active'},
+        ['Menu', 'IconName']
+    );
+
+    assert.deepEqual(
+        [...names],
+        ['Status', 'Menu', 'IconName']
+    );
+});
+
+
+test('the icon property group covers regular and attention icons', () => {
+    assert.deepEqual(ICON_PROPERTIES, [
+        'IconName',
+        'IconPixmap',
+        'AttentionIconName',
+        'AttentionIconPixmap',
+        'IconThemePath',
+    ]);
+});


### PR DESCRIPTION
### Motivation
- Consolidate icon-name normalization and property-change logic to make icon resolution and SNI property handling clearer and more testable.
- Add small runtime fixes for toggle lifecycle and clarify README about service ownership and inclusion/exclusion intent.

### Description
- Extracted `normalizeIconName` into `src/iconNames.js` and updated `src/iconUtils.js` to import and re-export it, removing the duplicate implementation.
- Introduced `src/propertyChanges.js` with `collectChangedPropertyNames` and `ICON_PROPERTIES`, and updated `src/statusNotifierItem.js` to use these helpers to drive `icon-changed`, `status-changed`, and `menu-changed` events.
- Adjusted `src/runningAppsToggle.js` to connect a `destroy` handler and move teardown logic into `_onDestroy` to properly restore GNOME menu behavior and clean up items.
- Added `package.json` with `type: "module"` and a `test` script, plus unit tests `test/iconNames.test.js` and `test/propertyChanges.test.js` exercising the new helpers.
- Updated `README.md` wording, task checklist, and added a note that the extension provides the `org.kde.StatusNotifierWatcher` service and cannot run alongside another extension that owns the same service.

### Testing
- Ran the unit tests with `npm test` (which runs `node --test`) against `test/iconNames.test.js` and `test/propertyChanges.test.js`, and they passed.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9068a9482c832894d92e62e4c1cd89)