### PR TITLE
Keep nested DBus submenus out of QuickToggle tracking

### DIFF
--- a/src/compat.js
+++ b/src/compat.js
@@ -1,31 +1,3 @@
 import * as Config from "resource:///org/gnome/shell/misc/config.js";
-import { setOpenedSubMenu } from "./ui/submenuState.js";
 
 export const [major, minor] = Config.PACKAGE_VERSION.split(".").map((s) => Number(s));
-
-/**
- * GNOME Shell's PopupMenu tracks a single opened submenu at the top-menu
- * level. PopupSubMenuMenuItem propagates its parent to nested submenus, so a
- * nested submenu also calls the top menu's _setOpenedSubMenu(). The stock
- * implementation closes the currently tracked submenu unconditionally,
- * which collapses our outer RunningAppItem menu.
- *
- * Keep the private Shell API touchpoint here so version-specific handling can
- * be added in one place if GNOME changes submenu tracking in a future release.
- *
- * Returns a cleanup function that restores Shell's original implementation.
- */
-export function enableNestedSubmenuTracking(rootMenu) {
-  const originalSetOpenedSubMenu = rootMenu._setOpenedSubMenu;
-  const setNestedOpenedSubMenu = (submenu) => {
-    setOpenedSubMenu(rootMenu, submenu);
-  };
-
-  rootMenu._setOpenedSubMenu = setNestedOpenedSubMenu;
-
-  return () => {
-    if (rootMenu._setOpenedSubMenu === setNestedOpenedSubMenu) {
-      rootMenu._setOpenedSubMenu = originalSetOpenedSubMenu;
-    }
-  };
-}

--- a/src/compat.js
+++ b/src/compat.js
@@ -17,13 +17,14 @@ export const [major, minor] = Config.PACKAGE_VERSION.split(".").map((s) => Numbe
  */
 export function enableNestedSubmenuTracking(rootMenu) {
   const originalSetOpenedSubMenu = rootMenu._setOpenedSubMenu;
-
-  rootMenu._setOpenedSubMenu = (submenu) => {
+  const setNestedOpenedSubMenu = (submenu) => {
     setOpenedSubMenu(rootMenu, submenu);
   };
 
+  rootMenu._setOpenedSubMenu = setNestedOpenedSubMenu;
+
   return () => {
-    if (rootMenu._setOpenedSubMenu !== originalSetOpenedSubMenu) {
+    if (rootMenu._setOpenedSubMenu === setNestedOpenedSubMenu) {
       rootMenu._setOpenedSubMenu = originalSetOpenedSubMenu;
     }
   };

--- a/src/compat.js
+++ b/src/compat.js
@@ -1,16 +1,30 @@
 import * as Config from "resource:///org/gnome/shell/misc/config.js";
-const [major, minor] = Config.PACKAGE_VERSION.split(".").map((s) => Number(s));
+import { setOpenedSubMenu } from "./ui/submenuState.js";
+
+export const [major, minor] = Config.PACKAGE_VERSION.split(".").map((s) => Number(s));
 
 /**
- * Example :
+ * GNOME Shell's PopupMenu tracks a single opened submenu at the top-menu
+ * level. PopupSubMenuMenuItem propagates its parent to nested submenus, so a
+ * nested submenu also calls the top menu's _setOpenedSubMenu(). The stock
+ * implementation closes the currently tracked submenu unconditionally,
+ * which collapses our outer RunningAppItem menu.
  *
- * import compat/gnome_version.js
- * export function generic_name(all_possible_args) {
- *   switch version :
- *     case v_one :
- *       return version_specific_code()
- *     default:
- *       return latest_version()
- * }
+ * Keep the private Shell API touchpoint here so version-specific handling can
+ * be added in one place if GNOME changes submenu tracking in a future release.
  *
+ * Returns a cleanup function that restores Shell's original implementation.
  */
+export function enableNestedSubmenuTracking(rootMenu) {
+  const originalSetOpenedSubMenu = rootMenu._setOpenedSubMenu;
+
+  rootMenu._setOpenedSubMenu = (submenu) => {
+    setOpenedSubMenu(rootMenu, submenu);
+  };
+
+  return () => {
+    if (rootMenu._setOpenedSubMenu !== originalSetOpenedSubMenu) {
+      rootMenu._setOpenedSubMenu = originalSetOpenedSubMenu;
+    }
+  };
+}

--- a/src/dbusMenu.js
+++ b/src/dbusMenu.js
@@ -17,11 +17,9 @@ class DBusPopupSubMenuMenuItem extends PopupMenu.PopupSubMenuMenuItem {
 
     if (open) {
       this.add_style_pseudo_class("open");
-
       const current = openedSubmenuByParent.get(parent);
       if (current && current !== this.menu) current.close(true);
       openedSubmenuByParent.set(parent, this.menu);
-
       this.add_accessible_state(Atk.StateType.EXPANDED);
       this.add_style_pseudo_class("checked");
       return;
@@ -44,81 +42,53 @@ export class DBusMenuClient {
     this._signals = createSignalManager();
 
     this._proxy = Gio.DBusProxy.new_for_bus_sync(
-      Gio.BusType.SESSION,
-      Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
-      null,
-      busName,
-      objectPath,
-      DBUS_MENU_IFACE,
-      null,
+      Gio.BusType.SESSION, Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES, null,
+      busName, objectPath, DBUS_MENU_IFACE, null,
     );
-
-    this._signals.connect(this._proxy, "g-signal", (_proxy, _sender, signal, _params) => {
-      if (signal === "LayoutUpdated" || signal === "ItemsPropertiesUpdated") {
-        this.reload();
-      }
+    this._signals.connect(this._proxy, "g-signal", (_proxy, _sender, signal) => {
+      if (signal === "LayoutUpdated" || signal === "ItemsPropertiesUpdated") this.reload();
     });
   }
 
   attachToMenu(menu) {
     this._menu = menu;
     this._signals.connect(menu, "open-state-changed", (_menu, open) => {
-      if (!open) return;
-
-      this._prepareAndReload(0);
+      if (open) this._prepareAndReload(0);
     });
-
     this._prepareAndReload(0);
   }
 
-  _prepareAndReload(id) {
-    this.aboutToShow(id);
-    this.reload();
-  }
+  _prepareAndReload(id) { this.aboutToShow(id); this.reload(); }
 
   async reload() {
     if (this._destroyed || !this._menu) return;
-
     try {
       const result = await Gio.DBus.session.call(
-        this._busName,
-        this._objectPath,
-        DBUS_MENU_IFACE,
-        "GetLayout",
-        new GLib.Variant("(iias)", [0, -1, []]),
-        null,
-        Gio.DBusCallFlags.NONE,
-        3000,
-        null,
+        this._busName, this._objectPath, DBUS_MENU_IFACE, "GetLayout",
+        new GLib.Variant("(iias)", [0, -1, []]), null, Gio.DBusCallFlags.NONE, 3000, null,
       );
-
       if (this._destroyed || !this._menu) return;
-
       const unpacked = result.deep_unpack();
-      const layout = normalizeVariant(unpacked[1]);
-      this._render(layout);
+      this._render(normalizeVariant(unpacked[1]));
     } catch (e) {
-      if (e.matches?.(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD)) return;
-      logError(e, `Unable to load DBusMenu ${this._busName}${this._objectPath}`);
+      if (!e.matches?.(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD))
+        logError(e, `Unable to load DBusMenu ${this._busName}${this._objectPath}`);
     }
   }
 
   _render(root) {
     if (!root || !this._menu) return;
-
     this._menu.removeAll();
-    const [_rootId, _rootProperties, children] = root;
+    const [, , children] = root;
     for (const child of children ?? []) {
       const item = this._createMenuItem(normalizeVariant(child));
       if (item) this._menu.addMenuItem(item);
     }
-
     this._setSubmenuPreviewHeight(this._menu);
   }
 
   _createMenuItem(node) {
     if (!node) return null;
-
     const [id, properties, children] = node;
     const props = normalizeProperties(properties);
     if (props.visible === false) return null;
@@ -127,41 +97,32 @@ export class DBusMenuClient {
     const childNodes = (children ?? []).map(normalizeVariant);
     const hasSubmenu = props["children-display"] === "submenu" || childNodes.length > 0;
     const item = this._createStandardItem(props, hasSubmenu);
-
     this._applyItemState(item, props);
     this._applyIcon(item, props);
-
     if (hasSubmenu) this._populateSubmenu(item, id, childNodes);
     if (item instanceof PopupMenu.PopupMenuItem) this._connectItemActivation(item, id);
-
     return item;
   }
 
   _createStandardItem(props, hasSubmenu) {
     const label = cleanLabel(props.label ?? "");
-    return hasSubmenu
-      ? new DBusPopupSubMenuMenuItem(label)
-      : new PopupMenu.PopupMenuItem(label);
+    return hasSubmenu ? new DBusPopupSubMenuMenuItem(label) : new PopupMenu.PopupMenuItem(label);
   }
 
   _applyItemState(item, props) {
     item.setSensitive(props.enabled !== false);
-
-    if (props["toggle-type"] === "checkmark" && props["toggle-state"] > 0) {
+    if (props["toggle-type"] === "checkmark" && props["toggle-state"] > 0)
       item.setOrnament(PopupMenu.Ornament.CHECK);
-    } else if (props["toggle-type"] === "radio" && props["toggle-state"] > 0) {
+    else if (props["toggle-type"] === "radio" && props["toggle-state"] > 0)
       item.setOrnament(PopupMenu.Ornament.DOT);
-    }
   }
 
   _populateSubmenu(item, id, childNodes) {
     item.menu.actor.add_style_class_name("running-app-submenu");
-
     for (const child of childNodes) {
       const childItem = this._createMenuItem(child);
       if (childItem) item.menu.addMenuItem(childItem);
     }
-
     this._setSubmenuPreviewHeight(item.menu);
     item.menu.connect("open-state-changed", (_menu, open) => {
       if (open) this._openSubmenu(id, item.menu);
@@ -170,8 +131,7 @@ export class DBusMenuClient {
 
   _connectItemActivation(item, id) {
     item.connect("activate", (_item, event) => {
-      const timestamp = event?.get_time?.() ?? 0;
-      this.event(id, "clicked", new GLib.Variant("i", 0), timestamp);
+      this.event(id, "clicked", new GLib.Variant("i", 0), event?.get_time?.() ?? 0);
     });
   }
 
@@ -183,8 +143,7 @@ export class DBusMenuClient {
 
   _setSubmenuPreviewHeight(menu) {
     const children = menu.box.get_children().filter((child) => child.visible);
-    const heights = children.map((child) => child.get_preferred_height(-1)[1]);
-    menu.actor.style = previewStyle(menu.actor.style, heights);
+    menu.actor.style = previewStyle(menu.actor.style, children.map((child) => child.get_preferred_height(-1)[1]));
   }
 
   _revealSubmenuPreview(menu) {
@@ -199,27 +158,20 @@ export class DBusMenuClient {
 
   _revealAllocatedSubmenu(menu) {
     if (this._destroyed || !menu.isOpen) return;
-
     const scrollView = menu._parent?.actor;
     const adjustment = scrollView?.get_vadjustment?.();
     const children = menu.box.get_children().filter((child) => child.visible);
     const lastPreviewItem = children[Math.min(children.length, SUBMENU_PREVIEW_ITEMS) - 1];
-
     if (!adjustment || !lastPreviewItem || adjustment.page_size <= 0) return;
 
     const [, menuY] = menu.actor.get_transformed_position();
     const [, itemY] = lastPreviewItem.get_transformed_position();
     const [, itemHeight] = lastPreviewItem.get_transformed_size();
     const [, scrollY] = scrollView.get_transformed_position();
-    const targetTop = adjustment.value + menuY - scrollY;
-    const targetBottom = adjustment.value + itemY + itemHeight - scrollY;
-
     adjustment.value = revealAdjustment(
-      adjustment.value,
-      adjustment.page_size,
-      adjustment.upper,
-      targetTop,
-      targetBottom,
+      adjustment.value, adjustment.page_size, adjustment.upper,
+      adjustment.value + menuY - scrollY,
+      adjustment.value + itemY + itemHeight - scrollY,
     );
   }
 
@@ -227,76 +179,45 @@ export class DBusMenuClient {
     const iconName = props["icon-name"];
     const iconData = props["icon-data"];
     if (!iconName && !iconData) return;
-
     const icon = new St.Icon({ iconSize: 20, styleClass: "popup-menu-icon" });
     if (item.label) item.label.x_expand = true;
     item.insert_child_at_index(icon, 1);
-
-    if (iconName) {
-      icon.iconName = normalizeIconName(iconName);
-      return;
-    }
-
+    if (iconName) { icon.iconName = normalizeIconName(iconName); return; }
     setDbusMenuIconData(icon, iconData, 20).catch((e) => logError(e, "Unable to render DBusMenu icon"));
   }
 
   event(id, eventName, data = null, timestamp = 0) {
     if (this._destroyed) return;
-
     data ??= new GLib.Variant("i", 0);
     Gio.DBus.session.call(
-      this._busName,
-      this._objectPath,
-      DBUS_MENU_IFACE,
-      "Event",
-      new GLib.Variant("(isvu)", [id, eventName, data, timestamp]),
-      null,
-      Gio.DBusCallFlags.NONE,
-      2000,
-      null,
-      (_connection, result) => {
-        try {
-          Gio.DBus.session.call_finish(result);
-        } catch (e) {
-          logError(e, "DBusMenu.Event");
-        }
+      this._busName, this._objectPath, DBUS_MENU_IFACE, "Event",
+      new GLib.Variant("(isvu)", [id, eventName, data, timestamp]), null,
+      Gio.DBusCallFlags.NONE, 2000, null, (_connection, result) => {
+        try { Gio.DBus.session.call_finish(result); } catch (e) { logError(e, "DBusMenu.Event"); }
       },
     );
   }
 
   async aboutToShow(id) {
     if (this._destroyed) return;
-
     try {
       const result = await Gio.DBus.session.call(
-        this._busName,
-        this._objectPath,
-        DBUS_MENU_IFACE,
-        "AboutToShow",
-        new GLib.Variant("(i)"),
-        null,
-        Gio.DBusCallFlags.NONE,
-        1000,
-        null,
+        this._busName, this._objectPath, DBUS_MENU_IFACE, "AboutToShow",
+        new GLib.Variant("(i)", [id]), null, Gio.DBusCallFlags.NONE, 1000, null,
       );
-
       if (!result) return;
       if (result.is_of_type(new GLib.VariantType("(b)"))) {
         const [changed] = result.deep_unpack();
         if (changed) this.reload();
       }
     } catch (e) {
-      if (
-        e.matches?.(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD) ||
-        e.matches?.(Gio.DBusError, Gio.DBusError.FAILED)
-      ) return;
+      if (e.matches?.(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD) || e.matches?.(Gio.DBusError, Gio.DBusError.FAILED)) return;
       logError(e, "DBusMenu.AboutToShow");
     }
   }
 
   destroy() {
     if (this._destroyed) return;
-
     this._destroyed = true;
     const laters = global.compositor.get_laters();
     for (const id of this._laterIds) laters.remove(id);
@@ -319,6 +240,4 @@ function normalizeProperties(values) {
   return result;
 }
 
-function cleanLabel(label) {
-  return label.replace(/_([^_])/g, "$1");
-}
+function cleanLabel(label) { return label.replace(/_([^_])/g, "$1"); }

--- a/src/dbusMenu.js
+++ b/src/dbusMenu.js
@@ -1,3 +1,4 @@
+import Atk from "gi://Atk";
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import Meta from "gi://Meta";
@@ -7,6 +8,31 @@ import { DBUS_MENU_IFACE } from "./protocol/interfaces.js";
 import { previewStyle, revealAdjustment, SUBMENU_PREVIEW_ITEMS } from "./ui/submenuLayout.js";
 import { normalizeIconName, setDbusMenuIconData } from "./utils/iconUtils.js";
 import { createSignalManager } from "./utils/lifecycle.js";
+
+const openedSubmenuByParent = new WeakMap();
+
+class DBusPopupSubMenuMenuItem extends PopupMenu.PopupSubMenuMenuItem {
+  _subMenuOpenStateChanged(_menu, open) {
+    const parent = this.menu._parent;
+
+    if (open) {
+      this.add_style_pseudo_class("open");
+
+      const current = openedSubmenuByParent.get(parent);
+      if (current && current !== this.menu) current.close(true);
+      openedSubmenuByParent.set(parent, this.menu);
+
+      this.add_accessible_state(Atk.StateType.EXPANDED);
+      this.add_style_pseudo_class("checked");
+      return;
+    }
+
+    this.remove_style_pseudo_class("open");
+    if (openedSubmenuByParent.get(parent) === this.menu) openedSubmenuByParent.delete(parent);
+    this.remove_accessible_state(Atk.StateType.EXPANDED);
+    this.remove_style_pseudo_class("checked");
+  }
+}
 
 export class DBusMenuClient {
   constructor(busName, objectPath) {
@@ -51,9 +77,7 @@ export class DBusMenuClient {
   }
 
   async reload() {
-    if (this._destroyed || !this._menu) {
-      return;
-    }
+    if (this._destroyed || !this._menu) return;
 
     try {
       const result = await Gio.DBus.session.call(
@@ -68,35 +92,25 @@ export class DBusMenuClient {
         null,
       );
 
-      if (this._destroyed || !this._menu) {
-        return;
-      }
+      if (this._destroyed || !this._menu) return;
 
       const unpacked = result.deep_unpack();
       const layout = normalizeVariant(unpacked[1]);
       this._render(layout);
     } catch (e) {
-      if (e.matches?.(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD)) {
-        return;
-      }
-
+      if (e.matches?.(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD)) return;
       logError(e, `Unable to load DBusMenu ${this._busName}${this._objectPath}`);
     }
   }
 
   _render(root) {
-    if (!root || !this._menu) {
-      return;
-    }
+    if (!root || !this._menu) return;
 
     this._menu.removeAll();
     const [_rootId, _rootProperties, children] = root;
     for (const child of children ?? []) {
-      const node = normalizeVariant(child);
-      const item = this._createMenuItem(node);
-      if (item) {
-        this._menu.addMenuItem(item);
-      }
+      const item = this._createMenuItem(normalizeVariant(child));
+      if (item) this._menu.addMenuItem(item);
     }
 
     this._setSubmenuPreviewHeight(this._menu);
@@ -107,14 +121,8 @@ export class DBusMenuClient {
 
     const [id, properties, children] = node;
     const props = normalizeProperties(properties);
-
-    if (props.visible === false) {
-      return null;
-    }
-
-    if (props.type === "separator") {
-      return new PopupMenu.PopupSeparatorMenuItem();
-    }
+    if (props.visible === false) return null;
+    if (props.type === "separator") return new PopupMenu.PopupSeparatorMenuItem();
 
     const childNodes = (children ?? []).map(normalizeVariant);
     const hasSubmenu = props["children-display"] === "submenu" || childNodes.length > 0;
@@ -132,7 +140,7 @@ export class DBusMenuClient {
   _createStandardItem(props, hasSubmenu) {
     const label = cleanLabel(props.label ?? "");
     return hasSubmenu
-      ? new PopupMenu.PopupSubMenuMenuItem(label)
+      ? new DBusPopupSubMenuMenuItem(label)
       : new PopupMenu.PopupMenuItem(label);
   }
 
@@ -176,16 +184,10 @@ export class DBusMenuClient {
   _setSubmenuPreviewHeight(menu) {
     const children = menu.box.get_children().filter((child) => child.visible);
     const heights = children.map((child) => child.get_preferred_height(-1)[1]);
-
     menu.actor.style = previewStyle(menu.actor.style, heights);
   }
 
   _revealSubmenuPreview(menu) {
-    /*
-     * PopupSubMenu emits open-state-changed before showing and allocating its
-     * actor. Wait for that allocation, then reveal the preview rows in the
-     * nearest scrollable parent submenu.
-     */
     const laters = global.compositor.get_laters();
     const laterId = laters.add(Meta.LaterType.BEFORE_REDRAW, () => {
       this._laterIds.delete(laterId);
@@ -224,24 +226,10 @@ export class DBusMenuClient {
   _applyIcon(item, props) {
     const iconName = props["icon-name"];
     const iconData = props["icon-data"];
-
-    if (!iconName && !iconData) {
-      return;
-    }
+    if (!iconName && !iconData) return;
 
     const icon = new St.Icon({ iconSize: 20, styleClass: "popup-menu-icon" });
-
-    /*
-     * Keep the row label expandable.
-     */
-    if (item.label) {
-      item.label.x_expand = true;
-    }
-
-    /*
-     * Put the icon near the start of the row
-     * rather than appending it at the end.
-     */
+    if (item.label) item.label.x_expand = true;
     item.insert_child_at_index(icon, 1);
 
     if (iconName) {
@@ -249,9 +237,7 @@ export class DBusMenuClient {
       return;
     }
 
-    setDbusMenuIconData(icon, iconData, 20).catch((e) => {
-      logError(e, "Unable to render DBusMenu icon");
-    });
+    setDbusMenuIconData(icon, iconData, 20).catch((e) => logError(e, "Unable to render DBusMenu icon"));
   }
 
   event(id, eventName, data = null, timestamp = 0) {
@@ -287,7 +273,7 @@ export class DBusMenuClient {
         this._objectPath,
         DBUS_MENU_IFACE,
         "AboutToShow",
-        new GLib.Variant("(i)", [id]),
+        new GLib.Variant("(i)"),
         null,
         Gio.DBusCallFlags.NONE,
         1000,
@@ -295,25 +281,15 @@ export class DBusMenuClient {
       );
 
       if (!result) return;
-
       if (result.is_of_type(new GLib.VariantType("(b)"))) {
         const [changed] = result.deep_unpack();
-        if (changed) {
-          this.reload();
-        }
+        if (changed) this.reload();
       }
     } catch (e) {
-      /*
-       * Some implementations omit or break
-       * AboutToShow.
-       */
       if (
         e.matches?.(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD) ||
         e.matches?.(Gio.DBusError, Gio.DBusError.FAILED)
-      ) {
-        return;
-      }
-
+      ) return;
       logError(e, "DBusMenu.AboutToShow");
     }
   }
@@ -323,11 +299,8 @@ export class DBusMenuClient {
 
     this._destroyed = true;
     const laters = global.compositor.get_laters();
-
     for (const id of this._laterIds) laters.remove(id);
-
     this._laterIds.clear();
-
     this._signals.reset();
     this._proxy = null;
     this._menu = null;
@@ -335,24 +308,14 @@ export class DBusMenuClient {
 }
 
 function normalizeVariant(value) {
-  while (value instanceof GLib.Variant) {
-    value = value.deep_unpack();
-  }
-
-  if (Array.isArray(value)) {
-    return value.map(normalizeVariant);
-  }
-
+  while (value instanceof GLib.Variant) value = value.deep_unpack();
+  if (Array.isArray(value)) return value.map(normalizeVariant);
   return value;
 }
 
 function normalizeProperties(values) {
   const result = {};
-
-  for (const [name, value] of Object.entries(values ?? {})) {
-    result[name] = normalizeVariant(value);
-  }
-
+  for (const [name, value] of Object.entries(values ?? {})) result[name] = normalizeVariant(value);
   return result;
 }
 

--- a/src/ui/runningAppsWidget.js
+++ b/src/ui/runningAppsWidget.js
@@ -1,9 +1,9 @@
 import GObject from "gi://GObject";
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 import { QuickToggle } from "resource:///org/gnome/shell/ui/quickSettings.js";
+import { enableNestedSubmenuTracking } from "../compat.js";
 import { IndicatorItems } from "./indicatorItems.js";
 import { RunningAppItem } from "./runningAppItem.js";
-import { setOpenedSubMenu } from "./submenuState.js";
 
 const MAX_MENU_HEIGHT_KEY = "max-menu-height";
 
@@ -15,7 +15,7 @@ export const RunningAppsWidget = GObject.registerClass(
       this._settings = settings;
       this._configureAppearance();
       this._initializeItems();
-      this._overrideSubmenuTracking();
+      this._disableNestedSubmenuTracking = enableNestedSubmenuTracking(this.menu);
       this._connectWidgetSignals();
     }
 
@@ -44,29 +44,6 @@ export const RunningAppsWidget = GObject.registerClass(
       this.visible = false;
     }
 
-    _overrideSubmenuTracking() {
-      /*
-       * GNOME normally assumes one submenu level:
-       *
-       * root
-       *   -> submenu
-       *
-       * We have:
-       *
-       * root
-       *   -> RunningAppItem.menu
-       *      -> DBusMenu submenu
-       *
-       * Opening the DBusMenu submenu must not close
-       * RunningAppItem.menu.
-       */
-      this._originalSetOpenedSubMenu = this.menu._setOpenedSubMenu;
-
-      this.menu._setOpenedSubMenu = (submenu) => {
-        this._setOpenedSubMenu(submenu);
-      };
-    }
-
     _connectWidgetSignals() {
       this._settingsChangedId = this._settings.connect(`changed::${MAX_MENU_HEIGHT_KEY}`, () =>
         this._syncMaxMenuHeight(),
@@ -77,10 +54,6 @@ export const RunningAppsWidget = GObject.registerClass(
       });
 
       this.connect("destroy", () => this._onDestroy());
-    }
-
-    _setOpenedSubMenu(submenu) {
-      setOpenedSubMenu(this.menu, submenu);
     }
 
     addIndicator(indicator) {
@@ -106,14 +79,8 @@ export const RunningAppsWidget = GObject.registerClass(
       this._settingsChangedId = 0;
       this._settings = null;
 
-      /*
-       * Restore GNOME's original method.
-       */
-      if (this._originalSetOpenedSubMenu) {
-        this.menu._setOpenedSubMenu = this._originalSetOpenedSubMenu;
-      }
-
-      this._originalSetOpenedSubMenu = null;
+      this._disableNestedSubmenuTracking?.();
+      this._disableNestedSubmenuTracking = null;
 
       this._items.destroyAll();
     }

--- a/src/ui/runningAppsWidget.js
+++ b/src/ui/runningAppsWidget.js
@@ -1,7 +1,6 @@
 import GObject from "gi://GObject";
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 import { QuickToggle } from "resource:///org/gnome/shell/ui/quickSettings.js";
-import { enableNestedSubmenuTracking } from "../compat.js";
 import { IndicatorItems } from "./indicatorItems.js";
 import { RunningAppItem } from "./runningAppItem.js";
 
@@ -15,7 +14,6 @@ export const RunningAppsWidget = GObject.registerClass(
       this._settings = settings;
       this._configureAppearance();
       this._initializeItems();
-      this._disableNestedSubmenuTracking = enableNestedSubmenuTracking(this.menu);
       this._connectWidgetSignals();
     }
 
@@ -78,9 +76,6 @@ export const RunningAppsWidget = GObject.registerClass(
       }
       this._settingsChangedId = 0;
       this._settings = null;
-
-      this._disableNestedSubmenuTracking?.();
-      this._disableNestedSubmenuTracking = null;
 
       this._items.destroyAll();
     }


### PR DESCRIPTION
## Why

GNOME Shell's stock `PopupSubMenuMenuItem` reports every opened submenu to `_getTopMenu()._setOpenedSubMenu()`. In our hierarchy:

```
QuickToggle.menu
└── RunningAppItem.menu
    └── DBus submenu
        └── deeper DBus submenu
```

that means a DBus submenu competes with `RunningAppItem.menu` for the QuickToggle root's single `_openedSubMenu` slot. Shell closes the outer app menu when the nested DBus submenu opens.

The previous implementation worked around this by monkey-patching `QuickToggle.menu._setOpenedSubMenu`. Moving that patch into `compat.js` would only move the fragility, not remove it.

## This PR

- removes the `_setOpenedSubMenu` monkey-patch from `RunningAppsWidget`
- keeps the outer `RunningAppItem` as GNOME's stock `PopupSubMenuMenuItem`, so QuickToggle continues to manage app-level sibling menus normally
- introduces a small `DBusPopupSubMenuMenuItem` subclass only for DBusMenu-generated submenu rows
- overrides the submenu open-state callback so DBus submenus do **not** register themselves with the QuickToggle root
- tracks the currently opened DBus submenu per immediate parent using a `WeakMap`, preserving normal sibling-closing behavior at every DBus nesting level
- leaves ordinary DBus menu items and the existing DBusMenu rendering path unchanged

This contains the behavioral difference to the menu items we own instead of modifying a GNOME-owned root menu method.

## Expected hierarchy

```
QuickToggle root tracking:
  app A / app B

DBus parent tracking:
  submenu A / submenu B

Nested DBus parent tracking:
  child A / child B
```

## Testing needed

This is intentionally still a draft. It should be exercised with `npm run mock:indicator`, especially:

- opening a DBus submenu without collapsing the app menu
- switching sibling DBus submenus
- deeply nested submenus
- switching between app menus
- keyboard navigation / accessibility state
- GNOME 48 and current GNOME 51

@codex review