### PR TITLE
Add option to hide passive indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ npm run mock:indicator
 
 This publishes a disposable StatusNotifierItem containing short, long, and deeply nested DBusMenu submenus for testing.
 
+Go through the package json for other possible tests
+
 ## Credits
 
 A lot of the implementation is based on the [AppIndicator/KStatusNotifierItem](https://github.com/ubuntu/gnome-shell-extension-appindicator) extension.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "schemas": "glib-compile-schemas --strict schemas",
     "test": "node --test",
     "mock:indicator": "gjs -m test/mock-indicator.gjs",
+    "mock:indicator:passive": "gjs -m test/mock-indicator.gjs --passive",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check"
   },

--- a/prefs.js
+++ b/prefs.js
@@ -31,11 +31,23 @@ export default class AppIndicatorQuickSettingsPreferences extends ExtensionPrefe
     });
     appearanceGroup.add(maxMenuHeight);
 
+    const hidePassiveIndicators = new Adw.SwitchRow({
+      title: _("Hide passive indicators"),
+      subtitle: _("Only show passive apps when they become active or need attention"),
+    });
+    appearanceGroup.add(hidePassiveIndicators);
+
     window._settings = this.getSettings();
     maxMenuHeight.value = window._settings.get_int("max-menu-height");
     maxMenuHeight.connect("notify::value", () => {
       window._settings?.set_int("max-menu-height", Math.round(maxMenuHeight.value));
     });
+    window._settings.bind(
+      "hide-passive-indicators",
+      hidePassiveIndicators,
+      "active",
+      0,
+    );
     window.connect("close-request", () => {
       window._settings = null;
     });

--- a/schemas/org.gnome.shell.extensions.appindicator-quicksetting.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.appindicator-quicksetting.gschema.xml
@@ -10,5 +10,10 @@
       <summary>Maximum menu height</summary>
       <description>The height in pixels at which the Running Apps menu becomes scrollable.</description>
     </key>
+    <key name="hide-passive-indicators" type="b">
+      <default>false</default>
+      <summary>Hide passive indicators</summary>
+      <description>Hide StatusNotifierItems whose status is Passive.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/ui/indicatorItems.js
+++ b/src/ui/indicatorItems.js
@@ -9,6 +9,13 @@ export class IndicatorItems {
     return this._items.size;
   }
 
+  get hasVisibleItems() {
+    for (const item of this._items.values()) {
+      if (item.visible) return true;
+    }
+    return false;
+  }
+
   add(indicator) {
     if (this._items.has(indicator.uniqueId)) return null;
 

--- a/src/ui/runningAppItem.js
+++ b/src/ui/runningAppItem.js
@@ -7,13 +7,16 @@ import { getIndicatorName } from "../utils/appNames.js";
 import { setSniIcon } from "../utils/iconUtils.js";
 import { createSignalManager, resetDisposable } from "../utils/lifecycle.js";
 
+const HIDE_PASSIVE_INDICATORS_KEY = "hide-passive-indicators";
+
 export const RunningAppItem = GObject.registerClass(
   class RunningAppItem extends PopupMenu.PopupSubMenuMenuItem {
-    _init(indicator) {
+    _init(indicator, settings) {
       super._init(getIndicatorName(indicator));
       this.menu.actor.add_style_class_name("running-app-submenu");
 
       this._indicator = indicator;
+      this._settings = settings;
       this._dbusMenu = null;
       this._signals = createSignalManager();
 
@@ -38,12 +41,22 @@ export const RunningAppItem = GObject.registerClass(
       this._signals.connect(this._indicator, "status-changed", () => this._sync());
       this._signals.connect(this._indicator, "icon-changed", () => this._syncIcon());
       this._signals.connect(this._indicator, "menu-changed", () => this._setupMenu());
+      this._signals.connect(
+        this._settings,
+        `changed::${HIDE_PASSIVE_INDICATORS_KEY}`,
+        () => this._syncVisibility(),
+      );
     }
 
     _sync() {
       this.label.text = getIndicatorName(this._indicator);
-      this.visible = this._indicator.status !== SNIStatus.PASSIVE;
+      this._syncVisibility();
       this._syncIcon();
+    }
+
+    _syncVisibility() {
+      const hidePassive = this._settings.get_boolean(HIDE_PASSIVE_INDICATORS_KEY);
+      this.visible = !hidePassive || this._indicator.status !== SNIStatus.PASSIVE;
     }
 
     _syncIcon() {
@@ -93,6 +106,7 @@ export const RunningAppItem = GObject.registerClass(
 
       this._signals.reset();
       this._indicator = null;
+      this._settings = null;
       super.destroy();
     }
   },

--- a/src/ui/runningAppsWidget.js
+++ b/src/ui/runningAppsWidget.js
@@ -38,7 +38,7 @@ export const RunningAppsWidget = GObject.registerClass(
 
     _initializeItems() {
       this._items = new IndicatorItems(
-        (indicator) => new RunningAppItem(indicator),
+        (indicator) => new RunningAppItem(indicator, this._settings),
         (item) => this.menu.addMenuItem(item),
       );
       this.visible = false;

--- a/src/ui/runningAppsWidget.js
+++ b/src/ui/runningAppsWidget.js
@@ -39,7 +39,10 @@ export const RunningAppsWidget = GObject.registerClass(
     _initializeItems() {
       this._items = new IndicatorItems(
         (indicator) => new RunningAppItem(indicator, this._settings),
-        (item) => this.menu.addMenuItem(item),
+        (item) => {
+          this.menu.addMenuItem(item);
+          item.connect("notify::visible", () => this._syncVisibility());
+        },
       );
       this.visible = false;
     }
@@ -92,7 +95,8 @@ export const RunningAppsWidget = GObject.registerClass(
     }
 
     _syncVisibility() {
-      this.visible = this._items.size > 0;
+      this.visible = this._items.hasVisibleItems;
+      if (!this.visible) this.menu.close();
     }
 
     vfunc_clicked() {

--- a/test/indicatorItems.test.js
+++ b/test/indicatorItems.test.js
@@ -39,3 +39,24 @@ test("removes and destroys an app item", () => {
   assert.equal(items.remove(indicator), false);
   assert.deepEqual(destroyedIds, [indicator.uniqueId]);
 });
+
+test("visibility follows rendered items rather than registered indicators", () => {
+  const { items } = createHarness();
+  assert.equal(items.hasVisibleItems, false);
+
+  const passive = items.add({ uniqueId: "passive" });
+  passive.visible = false;
+  assert.equal(items.size, 1);
+  assert.equal(items.hasVisibleItems, false);
+
+  passive.visible = true;
+  assert.equal(items.hasVisibleItems, true);
+  passive.visible = false;
+  assert.equal(items.hasVisibleItems, false);
+
+  const active = items.add({ uniqueId: "active" });
+  active.visible = true;
+  assert.equal(items.hasVisibleItems, true);
+  items.remove({ uniqueId: "active" });
+  assert.equal(items.hasVisibleItems, false);
+});

--- a/test/mock-indicator.gjs
+++ b/test/mock-indicator.gjs
@@ -5,7 +5,10 @@
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 
-const BUS_NAME = "org.example.AppIndicatorMenuTest";
+const passive = ARGV.includes("--passive");
+const BUS_NAME = passive
+  ? "org.example.AppIndicatorPassiveTest"
+  : "org.example.AppIndicatorMenuTest";
 const ITEM_PATH = "/StatusNotifierItem";
 const MENU_PATH = "/Menu";
 const WATCHER_NAME = "org.kde.StatusNotifierWatcher";
@@ -136,13 +139,13 @@ const statusNotifier = {
     return "ApplicationStatus";
   },
   get Id() {
-    return "appindicator-menu-test";
+    return passive ? "appindicator-passive-test" : "appindicator-menu-test";
   },
   get Title() {
-    return "VPN Menu Stress Test";
+    return passive ? "Passive Indicator Test" : "VPN Menu Stress Test";
   },
   get Status() {
-    return "Active";
+    return passive ? "Passive" : "Active";
   },
   get IconName() {
     return "network-vpn-symbolic";
@@ -189,7 +192,7 @@ function registerWithWatcher() {
       1000,
       null,
     );
-    print("Mock indicator registered. Open Quick Settings → Running Apps.");
+    print(`Mock indicator registered (${statusNotifier.Status}). Open Quick Settings → Running Apps.`);
     return GLib.SOURCE_REMOVE;
   } catch (error) {
     printerr(`Waiting for ${WATCHER_NAME}: ${error.message}`);


### PR DESCRIPTION
## Summary
- add a global `hide-passive-indicators` preference
- expose it in Preferences
- dynamically hide `Passive` StatusNotifierItems when enabled
- immediately show items again when they become `Active` or `NeedsAttention`

Closes #8