### PR TITLE
Add tagged GNOME extension releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release GNOME Extension
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install GNOME packaging tools
+        run: sudo apt-get update && sudo apt-get install -y gnome-shell
+
+      - name: Build extension ZIP
+        run: npm run build
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/*.zip --generate-notes


### PR DESCRIPTION
Closes #20.

Adds a minimal release workflow for the extension:

- runs only when a `v*` tag is pushed
- reuses the existing `npm run build` / `gnome-extensions pack` packaging path
- creates the GitHub Release for the tag
- attaches the generated extension ZIP from `dist/`
- uses the runner's built-in `gh` CLI and `GITHUB_TOKEN`, avoiding a third-party release action

Normal pushes and pull requests do not trigger this workflow.